### PR TITLE
Issue #111: Adding embed widget to all visualizations

### DIFF
--- a/theme/visualization-embed-button.tpl.php
+++ b/theme/visualization-embed-button.tpl.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Template for visualization embed button.
+ *
+ * Variables:
+ * - $embed_url: the url of the rendered content to be embedded.
+ */
+?>
+<div class="visualization-embed">
+  <a class="embed-link" href="#embed-wrapper"><?php print t('Embed'); ?></a>
+  <div id="embed-wrapper" class="embed-code-wrapper">
+    <textarea class="embed-code" style="height: 25px;"><iframe width="960" height="660" src="<?php print $embed_url ?>" frameborder="0"></iframe></textarea>
+  </div>
+</div>

--- a/visualization_entity.js
+++ b/visualization_entity.js
@@ -1,0 +1,16 @@
+/**
+ * @file
+ * Provides behaviour for visualization views.
+ */
+
+(function ($) {
+  Drupal.behaviors.VisualizationEntity = {
+    attach: function (context) {
+      $(".visualization-embed .embed-code-wrapper").hide();
+      $(".visualization-embed a.embed-link").live('click', function(){
+        $(this).parents('.visualization-embed').find('.embed-code-wrapper').toggle();
+        return false;
+      });
+    },
+  };
+})(jQuery);

--- a/visualization_entity.module
+++ b/visualization_entity.module
@@ -33,9 +33,35 @@ function visualization_entity_theme($existing, $type, $theme, $path) {
       'template' => 'visualization-iframe',
       'path' => $tpls_path,
     ),
+    'visualization-embed-button' => array(
+      'variables' => array('embed_url' => NULL),
+      'template' => 'visualization-embed-button',
+      'path' => $tpls_path,
+    ),
   );
 }
 
+/**
+ * Implements hook_entity_view_alter().
+ */
+function visualization_entity_entity_view_alter(&$build, $type) {
+  if ($type === 'visualization' && $build['#view_mode'] === 'full') {
+    $build['#post_render'][] = 'visualization_entity_attach_embed_widget';
+  }
+}
+
+function visualization_entity_attach_embed_widget($markup, $element) {
+  $module_path = drupal_get_path('module', 'visualization_entity');
+  $embed_url = current_path();
+  if (!is_numeric(strpos($embed_url, '/iframe'))) {
+    $embed_url =  $embed_url . '/iframe';
+    $embed_url = url($embed_url, array('absolute' => TRUE));
+    $embed_button = theme('visualization-embed-button', array('embed_url' => $embed_url));
+    $markup .= $embed_button;
+    drupal_add_js($module_path . '/visualization_entity.js');
+  }
+  return $markup;
+}
 /**
  * Renders iframe view for choropleth visualization
  * @param int $entity_id


### PR DESCRIPTION
Nucivic/nucivic-internal#111 
## Acceptance Test
- [x] All visualizations bundles that inherit from visualization entity should present an embed button.

![screen shot 2014-09-25 at 3 53 13 pm](https://cloud.githubusercontent.com/assets/428070/4410363/6c8f60e8-44e5-11e4-8373-4da5980fa61c.png)
- [x] If i click on the button it should toggle a text area with info about the iframe tag needed to embed that viz

![screen shot 2014-09-25 at 3 54 03 pm](https://cloud.githubusercontent.com/assets/428070/4410377/7e6b7b4e-44e5-11e4-86c8-411ee880ec7d.png)
