### PR TITLE
Issue nucivic/dkan#268 removes json name validation

### DIFF
--- a/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.module
+++ b/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.module
@@ -366,15 +366,6 @@ function visualization_entity_choropleth_bundle_form_validate(&$form, &$form_sta
   $node = node_load($resource_id);
   $field_upload = $node->field_upload[LANGUAGE_NONE][0];
 
-  $geojson_id = $form_state['values']['field_geojson'][LANGUAGE_NONE][0]['target_id'];
-  $geojson = entity_load_single('geo_file', $geojson_id);
-
-  $name_attribute = $geojson->field_name_attribute[LANGUAGE_NONE][0]['value'];
-  $resource_columns = visualization_entity_csv_columns($field_upload);
-  // Name attribute must match a column name of resource.
-  if (!empty($name_attribute) && !in_array(strtolower($name_attribute), $resource_columns)) {
-    form_set_error('field_data_column', 'Name attribute must match a column name of resource.');
-  }
   // Data column must be a valid field in the csv file.
   if (!visualization_entity_choropleth_bundle_has_data_column($data_column, $field_upload)) {
     form_set_error('field_data_column', 'Data column must be a valid field in the csv file.');


### PR DESCRIPTION
This removes validation for the json name. In this commit: https://github.com/NuCivic/visualization_entity/commit/6dff056452a51cfac30e14eb9bd6566f6843a1f6 we made it possible to have a different data_column from the map_column. 

Now the map_column matches the geojson_key property in the geojson file. We are no longer using the field_name_attribute which this is checking for since that can be different depending on the data. We could have two resources:

| name | geojson_key | value |
| --- | --- | --- |
| aaron | us | awesome |
| teo | ar | the best |
| mariano | ar | amazing |

and

| name | country_name | value |
| --- | --- | --- |
| aaron | United States | incredible |
| teo | Argentina | best ever |
| mariano | Argentina | fantastic |

that both match up to the same geojson_file which might have property values of country_abbreviation (us, ar) and country_name (Unites States, Argentina).
### Acceptance test
- [x] Remove "name attribute" from geojson_file and create a choropleth map. "name attribute" on geojson_file should no longer be necessary.
