### PR TITLE
Removing circular dependency for recline reference field

### DIFF
--- a/modules/uuidreference_select/uuidreference_select.info
+++ b/modules/uuidreference_select/uuidreference_select.info
@@ -2,4 +2,3 @@ name = UUID Reference Select
 core = 7.x
 
 dependencies[] = uuidreference
-dependencies[] = visualization_entity_recline_field_reference


### PR DESCRIPTION
NuCivic/sldata#5

uuidreference->visualization_entity_recline_field_reference dependency NOT NEEDED.