### PR TITLE
Add visualization_entity_embed module

### DIFF
--- a/modules/visualization_entity_choropleth_bundle/theme/visualization--choropleth-embed.tpl.php
+++ b/modules/visualization_entity_choropleth_bundle/theme/visualization--choropleth-embed.tpl.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Custom theme implementation for Choropleth Visualization Entity Bundle.
+ *
+ * Available variables:
+ * - $content: An array of comment items. Use render($content) to print them all, or
+ *   print a subset such as render($content['field_example']). Use
+ *   hide($content['field_example']) to temporarily suppress the printing of a
+ *   given element.
+ * - $title: The (sanitized) entity label.
+ * - $url: Direct url of the current entity if specified.
+ * - $page: Flag for the full page state.
+ * - $classes: String of classes that can be used to style contextually through
+ *   CSS. It can be manipulated through the variable $classes_array from
+ *   preprocess functions. By default the following classes are available, where
+ *   the parts enclosed by {} are replaced by the appropriate values:
+ *   - entity-{ENTITY_TYPE}
+ *   - {ENTITY_TYPE}-{BUNDLE}
+ *
+ * Other variables:
+ * - $classes_array: Array of html class attribute values. It is flattened
+ *   into a string within the variable $classes.
+ *
+ * @see template_preprocess()
+ * @see template_preprocess_entity()
+ * @see template_process()
+ */
+
+?>
+<div class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+  <div id="visualization-choropleth-<?php print $visualization->id; ?>" class="recline-data-explorer">
+    <div class='data-view-sidebar'></div>
+    <div class='data-view-container'></div>
+  </div>
+</div>

--- a/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.css
+++ b/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.css
@@ -1,3 +1,14 @@
+
+html body.page-visualization.page-visualization-choropleth-visualization {
+  margin-top: 0px !important;
+  overflow: hidden;
+}
+
+body.page-visualization.page-visualization-choropleth-visualization
+.region-content {
+  margin: 0px;
+}
+
 .progress-info{
   position: absolute;
   z-index: 99999;
@@ -11,4 +22,19 @@
   margin-left: -162px;
   font-weight: bold;
   box-shadow: 0px 3px 7px #aaa;
+}
+
+.leaflet-overlay-pane svg {
+  width: auto !important;
+  height: auto !important;
+  display: block;
+}
+
+.leaflet-control{
+  color: black;
+}
+
+.leaflet-control-zoom-in,
+.leaflet-control-zoom-out {
+  color: black !important;
 }

--- a/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.js
+++ b/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.js
@@ -24,7 +24,6 @@
           resource = new recline.Model.Dataset({
             records: recline.Backend.CSV.parse(resource, resource.delimiter),
           });
-          console.log(resource);
           initView(resource);
         }
         else {
@@ -108,6 +107,10 @@
         container.append(view.el);
         sidebar.append(view.elSidebar);
         view.render();
+        $(window).on('resize', function(){
+          view.$el.find('.recline-map .map').height($(window).height() - 10);
+        });
+        view.$el.find('.recline-map .map').height($(window).height() - 10);
       }
       // Get page url from iteration number.
       function getPageURL(i, resource) {

--- a/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.module
+++ b/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.module
@@ -116,6 +116,11 @@ function visualization_entity_choropleth_bundle_libraries_info() {
 function visualization_entity_choropleth_bundle_theme($existing, $type, $theme, $path) {
   $tpls_path = drupal_get_path('module', 'visualization_entity_choropleth_bundle') . '/theme';
   return array(
+    'visualization__choropleth_embed' => array(
+      'variables' => array(),
+      'template' => 'visualization--choropleth-embed',
+      'path' => $tpls_path,
+    ),
     'visualization-entity-choropleth-color-scale-option' => array(
       'variables' => array(),
       'template' => 'choropleth-color-scale-option',
@@ -133,34 +138,78 @@ function visualization_entity_choropleth_bundle_theme($existing, $type, $theme, 
 }
 
 /**
+ * Load required libraries.
+ */
+function visualization_entity_choropleth_bundle_load_required_libraries() {
+  libraries_load('lodash');
+  libraries_load('backbone');
+  libraries_load('mustache');
+  libraries_load('csv');
+  libraries_load('recline');
+  libraries_load('leaflet');
+  libraries_load('leaflet_zoomtogeometries');
+  libraries_load('numeral');
+  libraries_load('chroma');
+  libraries_load('recline_choropleth');
+}
+
+/**
+ * Load a geojson file entity.
+ */
+function visualization_entity_choropleth_bundle_load_geojson($target_id) {
+  $geojson = entity_load_single('geo_file', $target_id);
+  $geojson_name_attribute = $geojson->field_name_attribute[LANGUAGE_NONE][0]['value'];
+  $geojson = $geojson->field_file[LANGUAGE_NONE][0]['uri'];
+  $geojson = drupal_realpath($geojson);
+  return json_decode(file_get_contents($geojson));
+}
+
+/**
+ * Creates renderable view for a visualization given a view mode.
+ */
+function visualization_entity_choropleth_bundle_render_map($visualization, $view_mode) {
+  if (!empty($visualization)) {
+    return entity_view('visualization', array($visualization), $view_mode);
+  }
+  else {
+    return MENU_NOT_FOUND;
+  }
+}
+
+function visualization_entity_choropleth_bundle_visualization_entity_embed_render_alter($vars) {
+  $visualization = $vars['visualization'];
+  if (!empty($visualization) && $visualization->type == 'choropleth_visualization' && $vars['conf']['local_source']) {
+    // TODO: In order to uncomment this code, visualization_entity_choropleth_map.js needs to
+    // be adapted to work with multiple viz intances at the same page.
+    // $entity_view = visualization_entity_choropleth_bundle_render_map($vars['visualization'], 'embed');
+    // $vars['block']->content = drupal_render($entity_view);
+  }
+}
+
+/**
+ * Implements hook_preprocess_entity().
+ */
+function visualization_entity_choropleth_bundle_preprocess_entity(&$vars) {
+  if ($vars['entity_type'] == 'visualization' && $vars['view_mode'] == 'embed') {
+    $vars['theme_hook_suggestions'] = array('visualization__choropleth_embed');
+  }
+}
+
+/**
  * Implements hook_entity_view_alter().
  */
 function visualization_entity_choropleth_bundle_entity_view_alter(&$build, $type) {
   if ($type === 'visualization' && $build['#entity']->type === 'choropleth_visualization') {
     // Load libraries.
-    libraries_load('lodash');
-    libraries_load('backbone');
-    libraries_load('mustache');
-    libraries_load('csv');
-    libraries_load('recline');
-    libraries_load('leaflet');
-    libraries_load('leaflet_zoomtogeometries');
-    libraries_load('numeral');
-    libraries_load('chroma');
-    libraries_load('recline_choropleth');
+    visualization_entity_choropleth_bundle_load_required_libraries();
 
     // Build settings.
     $settings = array();
 
+    $settings['eid'] = $build['#entity']->id;
+
     // Build geojson file.
-    $geojson = entity_load_single(
-      'geo_file',
-      $build['field_geojson']['#items'][0]['target_id']
-    );
-    $geojson_name_attribute = $geojson->field_name_attribute[LANGUAGE_NONE][0]['value'];
-    $geojson = $geojson->field_file[LANGUAGE_NONE][0]['uri'];
-    $geojson = drupal_realpath($geojson);
-    $geojson = json_decode(file_get_contents($geojson));
+    $geojson = visualization_entity_choropleth_bundle_load_geojson($build['field_geojson']['#items'][0]['target_id']);
 
     $settings['geojson'] = $geojson;
 
@@ -203,7 +252,6 @@ function visualization_entity_choropleth_bundle_entity_view_alter(&$build, $type
     else {
       $settings['map_column'] = $geojson_name_attribute;
     }
-
 
     // Build data_column.
     if (isset($build['field_data_column'])) {

--- a/modules/visualization_entity_embed/plugins/content_types/visualization_embed.inc
+++ b/modules/visualization_entity_embed/plugins/content_types/visualization_embed.inc
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Define a new ctools content type.
+ */
+
+$plugin = array(
+  'single' => TRUE,
+  'title' => t('Visualization embed'),
+  'description' => t('Creates an new embed using either a local or remote visualization'),
+  'category' => t('Visualizations'),
+  'edit form' => 'visualization_entity_embed_edit_form',
+  'render callback' => 'visualization_entity_embed_render',
+  'admin info' => 'visualization_entity_embed_admin_info',
+  'defaults' => array(
+    'local_source' => '',
+    'remote_source' => '',
+    'height' => '480',
+    'width' => '100%',
+  ),
+);

--- a/modules/visualization_entity_embed/visualization_entity_embed.info
+++ b/modules/visualization_entity_embed/visualization_entity_embed.info
@@ -1,0 +1,5 @@
+name = Visualization Entity Embed
+description = Allow users embed visualizations using panels and ctools content types
+core = 7.x
+
+dependencies[] = visualization_entity

--- a/modules/visualization_entity_embed/visualization_entity_embed.module
+++ b/modules/visualization_entity_embed/visualization_entity_embed.module
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * @file
+ * Creates a panel pane to allow users embed visualizations.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function visualization_entity_embed_menu() {
+  $items = array();
+  $items['visualization-entity-embed-autocomplete'] = array(
+    'page callback' => 'visualization_entity_embed_option_autocomplete',
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+  return $items;
+}
+
+/**
+ * Implements hook_ctools_plugin_directory().
+ */
+function visualization_entity_embed_ctools_plugin_directory($owner, $plugin_type) {
+  if ($owner == 'ctools' && $plugin_type == 'content_types') {
+    return 'plugins/' . $plugin_type;
+  }
+}
+
+/**
+ * The 'admin info' callback for panel pane.
+ */
+function visualization_entity_embed_admin_info($subtype, $conf, $contexts) {
+  if (!empty($conf)) {
+    $block = new stdClass();
+    $block->title = $conf['override_title'] ? $conf['override_title_text'] : '';
+    $block->content = t('Source: @source', array(
+      '@source' => $conf['source'],
+    ));
+
+    return $block;
+  }
+
+}
+
+/**
+ * The 'Edit form' callback for the content type.
+ */
+function visualization_entity_embed_edit_form($form, &$form_state) {
+  ctools_include('dependent');
+
+  $conf = $form_state['conf'];
+
+  /// Start from here
+  $form['source_origin'] = array(
+    '#title' => t('Source origin'),
+    '#description' => t(''),
+    '#type' => 'radios',
+    '#options' => array(
+      'local' => t('Local - created in DKAN'),
+      'remote' => t('External - paste your own url'),
+    ),
+    '#default_value' => (!empty($conf['source_origin'])) ? $conf['source_origin'] : 'local',
+    '#required' => FALSE,
+  );
+
+  $form['local_source'] = array(
+    '#title' => t('Visualization'),
+    '#description' => t('Start typing your visualization’s title for autocomplete'),
+    '#type' => 'textfield',
+    '#autocomplete_path' => 'visualization-entity-embed-autocomplete',
+    '#default_value' => $conf['source'],
+    '#attributes' => array(
+      'class' => array('form-control')
+    ),
+    '#process' => array('ctools_dependent_process'),
+    '#dependency' => array('radio:source_origin' => array('local')),
+    '#required' => FALSE,
+  );
+  $form['remote_source'] = array(
+    '#title' => t('Url'),
+    '#description' => t('Place a remote visualization url'),
+    '#type' => 'textfield',
+    '#default_value' => $conf['remote_source'],
+    '#attributes' => array(
+      'class' => array('form-control')
+    ),
+    '#process' => array('ctools_dependent_process'),
+    '#dependency' => array('radio:source_origin' => array('remote')),
+    '#required' => FALSE,
+  );
+  $form['width'] = array(
+    '#title' => t('Width'),
+    '#description' => t('Configure the width (e.g. 100%)'),
+    '#type' => 'textfield',
+    '#default_value' => $conf['width'],
+    '#required' => TRUE,
+  );
+  $form['height'] = array(
+    '#title' => t('Height'),
+    '#description' => t('Configure the height (e.g. 420)'),
+    '#type' => 'textfield',
+    '#default_value' => $conf['height'],
+    '#required' => TRUE,
+  );
+
+  return $form;
+}
+
+/**
+ * Autocomplete callback.
+ */
+function visualization_entity_embed_option_autocomplete($text) {
+  $query = db_select('eck_visualization', 'v')
+    ->condition('v.title', '%' . db_like($text) . '%', 'LIKE')
+    ->fields('v')
+    ->orderBy('created', 'desc');
+
+  $result = $query->execute()->fetchAll();
+
+  $options = array();
+  foreach ($result as $visualization) {
+    $options[$visualization->title . ' [id:' . $visualization->id . ']'] = $visualization->title;
+  }
+
+  return drupal_json_output($options);
+}
+
+/**
+ * The submit form stores the data in $conf.
+ */
+function visualization_entity_embed_edit_form_submit($form, &$form_state) {
+  foreach (array_keys($form_state['plugin']['defaults']) as $key) {
+    if (isset($form_state['values'][$key])) {
+      if($key === 'local_source' && !empty($form_state['values']['local_source'])) {
+        $form_state['conf']['local_source'] = $form_state['values']['local_source'];
+      } elseif ($key === 'remote_source' && !empty($form_state['values']['remote_source'])) {
+        $form_state['conf']['remote_source'] = $form_state['values']['remote_source'];
+      } else {
+        $form_state['conf'][$key] = $form_state['values'][$key];
+      }
+    }
+  }
+}
+
+/**
+ * The 'Render' callback for the content type.
+ */
+function visualization_entity_embed_render($subtype, $conf, $panel_args, $context = NULL) {
+
+  // Check if we need to load a local source or a remote.
+  if (!empty($conf['local_source'])) {
+    $source = check_plain($conf['local_source']);
+    $re = '/\\[id:(\\d+)\\]/';
+    preg_match($re, $source, $matches);
+    $source = $matches[1];
+    $visualization = entity_load_single('visualization', $source);
+    $source = '/visualization/' . $visualization->type . '/' . $visualization->id . '/iframe';
+  } else {
+    $source = check_plain($conf['remote_source']);
+    $visualization = '';
+  }
+
+  // Get with and height from the conf.
+  $width = check_plain($conf['width']);
+  $height = check_plain($conf['height']);
+
+  // Creates a block for embed.
+  $block = new stdClass();
+  $block->title = '';
+  $block->content = '<iframe src="' . $source . '" height="' . $height . '" width="' . $width . '" frameBorder="0" scrolling="no"></iframe>';
+
+  $embed = array(
+    'block' => $block,
+    'visualization' => $visualization,
+    'conf' => $conf,
+    'panels_args' => $panel_args,
+    'subtype' => $subtype,
+    'context' => $context,
+    'width' => $width,
+    'height' => $height,
+  );
+
+  // Allow other bundles modify how the embed is being rendered.
+  module_invoke_all('visualization_entity_embed_render_alter', $embed);
+
+  return $block;
+}

--- a/modules/visualization_entity_recline_field_reference/visualization_entity_recline_field_reference.module
+++ b/modules/visualization_entity_recline_field_reference/visualization_entity_recline_field_reference.module
@@ -1,7 +1,13 @@
 <?php
+/**
+ * @file
+ * Code for visualization entity recline fields.
+ */
 
 /**
  * Provide a list of content types that implement the recline field.
+ *
+ *
  * @return array List of content types have a recline field.
  */
 

--- a/visualization_entity.info
+++ b/visualization_entity.info
@@ -1,4 +1,5 @@
 name = Visualization Entity
+description = Base module to create visualizations
 core = 7.x
 package = NuCivic
 dependencies[] = eck

--- a/visualization_entity.js
+++ b/visualization_entity.js
@@ -15,12 +15,12 @@
         return false;
       });
       function renderIframeCode(e){
-      	var prop = (e.currentTarget.id === 'embed-height')? 'height': 'width';
-      	var value = ($(this).val()) ? $(this).val() : (prop === 'height')? '600' : '960';
+        var prop = (e.currentTarget.id === 'embed-height') ? 'height' : 'width';
+        var value = ($(this).val()) ? $(this).val() : (prop === 'height') ? '600' : '960';
 
-      	var iframe = $('.visualization-embed #embed-code').text();
-      	var newCode = $(iframe).prop(prop, value).get(0).outerHTML;
-      	$('.visualization-embed #embed-code').text(newCode);
+        var iframe = $('.visualization-embed #embed-code').text();
+        var newCode = $(iframe).prop(prop, value).get(0).outerHTML;
+        $('.visualization-embed #embed-code').text(newCode);
       }
     },
   };

--- a/visualization_entity.module
+++ b/visualization_entity.module
@@ -5,7 +5,7 @@
  */
 
 include_once 'visualization_entity.features.inc';
-include_once drupal_get_path('module', 'visualization_entity') .'/includes/utils.inc';
+include_once drupal_get_path('module', 'visualization_entity') . '/includes/utils.inc';
 
 /**
  * Implements hook_menu().
@@ -17,7 +17,7 @@ function visualization_entity_menu() {
       'page callback' => 'visualization_entity_iframe',
       'page arguments' => array(2),
       'access arguments' => array('access content'),
-    )
+    ),
   );
 }
 
@@ -58,7 +58,7 @@ function visualization_entity_attach_embed_widget($markup, $element) {
   $module_path = drupal_get_path('module', 'visualization_entity');
   $embed_url = current_path();
   if (!is_numeric(strpos($embed_url, '/iframe'))) {
-    $embed_url =  $embed_url . '/iframe';
+    $embed_url = $embed_url . '/iframe';
     $embed_url = url($embed_url, array('absolute' => TRUE));
     $embed_button = theme('visualization-embed-button', array('embed_url' => $embed_url));
     $markup .= $embed_button;
@@ -67,9 +67,11 @@ function visualization_entity_attach_embed_widget($markup, $element) {
   return $markup;
 }
 /**
- * Renders iframe view for visualization
+ * Renders iframe view for visualization.
+ *
  * @param int $entity_id
- *   The Entity id to load
+ *   The Entity id to load.
+ *
  * @return string
  *   A rendered entity or MENU_NOT_FOUND constant
  */


### PR DESCRIPTION
NuCivic/internal#308
NuCivic/internal#309

This module allows embed visualizations via panels using ctools content types.

### Acceptance test
- [x] git pull
- [x] drush en visualization_entity_embed
- [x] create a visualization (chart or choropleth)
- [x] go to any panel page (e.g. front page)
- [x] go to a variant
- [x] got to content
- [x] click on a wheel to add a new panel pane
- [x] click on add content
- [x] click on visualizations on the left side menu 
- [x] click on "add +" in the visualization
- [x] in the source file search for the title of your recently created viz
- [x] config the height and width
- [x] click on update and save
- [x] go to the panel page
- [x] visualization should be displayed.
- [x] repeat this with choropleth maps and using an external iframe as well.