### PR TITLE
Related NuCivic/saturn#13. Set resource as default target bundle

### DIFF
--- a/modules/visualization_entity_recline_field_reference/visualization_entity_recline_field_reference.features.field_base.inc
+++ b/modules/visualization_entity_recline_field_reference/visualization_entity_recline_field_reference.features.field_base.inc
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * visualization_entity.features.field_base.inc
+ * visualization_entity_recline_field_reference.features.field_base.inc
  */
 
 /**
@@ -31,7 +31,7 @@ function visualization_entity_recline_field_reference_field_default_field_bases(
         'dataset' => 0,
         'group' => 0,
         'page' => 0,
-        'resource' => 0,
+        'resource' => 'resource',
       ),
       'target_type' => 'node',
     ),
@@ -39,7 +39,7 @@ function visualization_entity_recline_field_reference_field_default_field_bases(
       'dataset' => 0,
       'group' => 0,
       'page' => 0,
-      'resource' => 0,
+      'resource' => 'resource',
     ),
     'translatable' => 0,
     'type' => 'uuidreference',

--- a/modules/visualization_entity_recline_field_reference/visualization_entity_recline_field_reference.info
+++ b/modules/visualization_entity_recline_field_reference/visualization_entity_recline_field_reference.info
@@ -8,5 +8,5 @@ dependencies[] = uuidreference
 dependencies[] = uuidreference_select
 features[features_api][] = api:2
 features[field_base][] = field_uuid_resource
-mtime = 1421114365
+mtime = 1426610294
 project path = sites/all/modules/nucivic


### PR DESCRIPTION
Settings are stored per field and not per field instance. Because this
we need to set resource as default target bundle in order to filter
other content types without resources.

Acceptance test
---------------------
- [x] In your projects folder: git clone git@github.com:NuCivic/visualization_entity.git
- [x] cd visualization_entity
- [x] git checkout saturn_13_existing_resource
- [x] In your projects folder: git clone git@github.com:NuCivic/visualization_entity_charts.git
- [x] cd visualization_entity_charts
- [x] git checkout saturn_13_existing_resource
- [x] cd dkan/webroot
- [x] mkdir -p sites/all/modules/nucivic
- [x] cd sites/all/modules/nucivic
- [x] ln -s ~/Projects/visualization_entity
- [x] ln -s ~/Projects/visualization_entity_charts
- [x] cd dkan/webroot
- [x] drush make --no-core sites/all/modules/nucivic/visualization_entity/visualization_entity.make -y
- [x] drush make --no-core sites/all/modules/nucivic/visualization_entity_charts/visualization_entity_charts.make -y
- [x] cd sites/all/modules/contrib
- [x] rm -rf entity
- [x] rm -rf features 
- [x] drush en visualization_entity_charts -y
- [x] go to admin/structure/entity-type/visualization/ve_chart/fields
- [x] edit the field_uuid_resource
- [x] go to field settings
- [x] Resource should be checked as target bundle
