### PR TITLE
Remove old permission.

### DIFF
--- a/modules/visualization_entity_visualization_contributor_role/visualization_entity_visualization_contributor_role.features.roles_permissions.inc
+++ b/modules/visualization_entity_visualization_contributor_role/visualization_entity_visualization_contributor_role.features.roles_permissions.inc
@@ -37,7 +37,6 @@ function visualization_entity_visualization_contributor_role_default_roles_permi
       'eck view geo_file geojson entities' => TRUE,
       'eck view visualization choropleth_visualization entities' => TRUE,
       'eck view visualization geojson_visualization entities' => TRUE,
-      'reference unpublished nodes' => TRUE,
     ),
   );
 


### PR DESCRIPTION
This module currently exports a permission that was defined by the
`entityreference_unpublished_node` that is no longer part of dkan.

This commit removes said permission.

Ref nucivic/healthdata#645.

- [ ] Verify that the permission is indeed not needed any more.
- [ ] Verify that this commit removes said permission.