### PR TITLE
Fixes csv column validation triming whitespaces + Fixes Chrome js library version info

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -77,7 +77,9 @@ function visualization_entity_has_csv_extension($file_field) {
  *  Get csv columns from a csv file.
  */
 function visualization_entity_csv_columns($file_field) {
-  return array_map('strtolower', visualization_entity_csv_row($file_field, 0));
+  $columns = array_map('strtolower', visualization_entity_csv_row($file_field, 0));
+  $columns = array_map('trim', $columns);
+  return $columns;
 }
 
 /**

--- a/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.module
+++ b/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.module
@@ -63,7 +63,10 @@ function visualization_entity_choropleth_bundle_libraries_info() {
     'vendor url' => 'http://driven-by-data.net/about/chromajs/#/0',
     'download url' => 'https://github.com/gka/chroma.js/zipball/master',
     'path' => '',
-    'version' => "1.1.1",
+    'version arguments' => array(
+      'file' => 'CHANGELOG',
+      'pattern' => '/# (\d+\.\d+\.\d+)/',
+    ),
     'files' => array(
       'js' => array(
         'chroma.min.js',


### PR DESCRIPTION
- Validation for valid csv columns was not working properly due to whitespaces coming off array_map call
- Chrome library info was trying to retrieve version from the wrong file

![screen shot 2016-05-12 at 2 21 24 pm](https://cloud.githubusercontent.com/assets/428070/15223967/6a34956a-184d-11e6-9555-064c7c0765ee.png)
![screen shot 2016-05-12 at 2 21 15 pm](https://cloud.githubusercontent.com/assets/428070/15223968/6a55188a-184d-11e6-8470-6d3f304d13b3.png)
