### PR TITLE
Remove duplicate parsing of geojson file

### DIFF
--- a/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.module
+++ b/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.module
@@ -313,16 +313,6 @@ function visualization_entity_choropleth_bundle_entity_view_alter(&$build, $type
       $settings['resources'][] = $resource_settings;
     }
 
-    // Build label column and geojson file.
-    $geojson = entity_load_single(
-      'geo_file',
-      $build['field_geojson']['#items'][0]['target_id']
-    );
-    $settings['label_column'] = $geojson->field_name_attribute[LANGUAGE_NONE][0]['value'];
-
-    $geojson = $geojson->field_file[LANGUAGE_NONE][0]['uri'];
-    $geojson = drupal_realpath($geojson);
-    $geojson = json_decode(file_get_contents($geojson));
     $settings['geojson'] = $geojson;
 
     $settings = array(


### PR DESCRIPTION
## Issue

https://github.com/NuCivic/dkan/issues/935
Civic-2231
## Description

Unnecessary second loading of the geo_file
 • visualization_entity_choropleth_bundle.module line 224
 • visualization_entity_choropleth_bundle.module line 317
## Acceptance Criteria
- [x] Enable the geo_file_entity and  choropleth bundle modules
- [x] Add a resource
- [x] Add a geojson file
- [x] Create a choropleth chart
- [x] Chart should display as expected
