### PR TITLE
Update external url field to add maxlength value

### DIFF
--- a/modules/visualization_entity_embed/visualization_entity_embed.module
+++ b/modules/visualization_entity_embed/visualization_entity_embed.module
@@ -57,8 +57,8 @@ function visualization_entity_embed_edit_form($form, &$form_state) {
     '#description' => t(''),
     '#type' => 'radios',
     '#options' => array(
-      'local' => t('Local - visualization content created in DKAN'),
-      'remote' => t('External - data previews'),
+      'local' => t('DKAN Visualization'),
+      'remote' => t('URL - use for external visualization services, or embed URLs from DKAN resource previews'),
     ),
     '#default_value' => (!empty($conf['source_origin'])) ? $conf['source_origin'] : 'local',
     '#required' => FALSE,
@@ -79,7 +79,7 @@ function visualization_entity_embed_edit_form($form, &$form_state) {
   );
   $form['remote_source'] = array(
     '#title' => t('Url'),
-    '#description' => t('Place a remote visualization url or a data preview url'),
+    '#description' => t('Enter an embed URL for a visualization'),
     '#type' => 'textfield',
     '#default_value' => $conf['remote_source'],
     '#attributes' => array(

--- a/modules/visualization_entity_embed/visualization_entity_embed.module
+++ b/modules/visualization_entity_embed/visualization_entity_embed.module
@@ -88,6 +88,7 @@ function visualization_entity_embed_edit_form($form, &$form_state) {
     '#process' => array('ctools_dependent_process'),
     '#dependency' => array('radio:source_origin' => array('remote')),
     '#required' => FALSE,
+    '#maxlength' => '500',
   );
   $form['width'] = array(
     '#title' => t('Width'),

--- a/modules/visualization_entity_embed/visualization_entity_embed.module
+++ b/modules/visualization_entity_embed/visualization_entity_embed.module
@@ -57,8 +57,8 @@ function visualization_entity_embed_edit_form($form, &$form_state) {
     '#description' => t(''),
     '#type' => 'radios',
     '#options' => array(
-      'local' => t('Local - created in DKAN'),
-      'remote' => t('External - paste your own url'),
+      'local' => t('Local - visualization content created in DKAN'),
+      'remote' => t('External - data previews'),
     ),
     '#default_value' => (!empty($conf['source_origin'])) ? $conf['source_origin'] : 'local',
     '#required' => FALSE,
@@ -79,7 +79,7 @@ function visualization_entity_embed_edit_form($form, &$form_state) {
   );
   $form['remote_source'] = array(
     '#title' => t('Url'),
-    '#description' => t('Place a remote visualization url'),
+    '#description' => t('Place a remote visualization url or a data preview url'),
     '#type' => 'textfield',
     '#default_value' => $conf['remote_source'],
     '#attributes' => array(


### PR DESCRIPTION
## Issue
civic-2710

## Description
Users may want to embed a recline preview on their page but text fields have a 128 character limit, this chops off long recline preview urls with config values such as:

http://krista.dkandemo.nuamsdev.com/node/5/recline-embed#{view-graph:{graphOptions:{hooks:{processOffset:{},bindEvents:{}}}},currentView:!map,graphOptions:{hooks:{processOffset:{},bindEvents:{}}},map:{bounds:{_southWest:{lat:42.95692504577836,lng:-89.70405578613281},_northEast:{lat:43.207678268758,lng:-89.07920837402344}}}}

![screenshot_5_31_16__1_35_pm](https://cloud.githubusercontent.com/assets/314172/15686142/933852d0-2734-11e6-8ccc-cd5a31a5dd45.png)

## Tasks
1. Add maxlength value to the external url field to allow long urls 
2. Update label on the external url field to read: Data preview or external URL
3. Add additional box on the resource page for the user to grab the preview url

## Steps to reproduce
1. log in and click the Customize this page button at the bottom of the home page
2. click the add content button, select visualization embed
3. select external for source origin
4. paste the above url into the url field (notice the url is cut off)
5. click finish, confirm the preview is not embedded

## Acceptance Criteria
 - [ ] When on a resource page I should see a second block below the 'Embed' code called 'Data Preview URL' that will give me the preview url to paste into the visualization embed panel.
 - [ ] You can use the visualization embed feature to add a recline preview with the 'external' url option

## PR dependency
- [x] https://github.com/NuCivic/recline/pull/41
- [ ] https://github.com/NuCivic/dkan/pull/1189

## QA site
https://github.com/NuCivic/dkan/pull/1164