### PR TITLE
Add uuid supports to eck entities

### DIFF
--- a/visualization_entity.features.inc
+++ b/visualization_entity.features.inc
@@ -33,6 +33,11 @@ function visualization_entity_eck_entity_type_info() {
           'type' => 'integer',
           'behavior' => 'changed',
         ),
+        'uuid' => array(
+          'behavior' => 'uuid',
+          'label' => 'UUID',
+          'type' => 'text',
+        )
       ),
     ),
   );

--- a/visualization_entity.install
+++ b/visualization_entity.install
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Implements hook_update_N().
+ */
+function visualization_entity_update_7001(){
+  features_revert(array('visualization_entity' => array('features')));
+  $entity_type = entity_type_load('visualization');
+  // Get all entity instances of this type.
+  $query = new EntityFieldQuery();
+  $query->entityCondition('entity_type', $entity_type->name, '=');
+
+  $results = $query->execute();
+  if (!empty($results)) {
+    $entities = entity_load($entity_type->name, array_keys($results[$entity_type->name]));
+  }
+  else {
+    $entities = array();
+  }
+
+  // Even when we don't need to explicitily
+  // assign a uuid I'm doing that because
+  // code has more sense with this.
+  foreach($entities as $entity) {
+    $entity->uuid = uuid_generate();
+    entity_save('visualization', $entity);
+  }
+}

--- a/visualization_entity.module
+++ b/visualization_entity.module
@@ -12,19 +12,40 @@ include_once drupal_get_path('module', 'visualization_entity') . '/includes/util
  * Load callback for %visualization_entity.
  */
 function visualization_entity_load($entity_id) {
-  if(is_numeric($entity_id)) {
-    $entity = entity_load_single(
-      'visualization',
-      $entity_id
-    );
-  } else if (function_exists('entity_uuid_load') && uuid_is_valid($entity_id)) {
-    $entity = entity_uuid_load('visualization', array($entity_id));
-    $entity =  ($entity) ? reset($entity) : FALSE;
-  } else {
+  try {
+
+    // Grab entity type from the url.
+    $entity_type = arg(0);
+
+    // To achieve the same behavior with other
+    // entity types we should use:
+    // $eck_types = array_keys(EntityType::loadAll());
+    // However at that point we should also move
+    // this code to another module since this module
+    // it's only related with visualizations.
+    $eck_types = array('visualization');
+
+    if(in_array($entity_type, $eck_types)) {
+
+      // Load entity by etid as usual.
+      if(is_numeric($entity_id)) {
+        return entity_load_single(
+          $entity_type,
+          $entity_id
+        );
+
+      // Load entity by uuid.
+      } else if (uuid_is_valid($entity_id) && function_exists('entity_uuid_load')) {
+        $entity = entity_uuid_load($entity_type, array($entity_id));
+        return ($entity) ? reset($entity) : FALSE;
+      }
+    }
+  } catch (Exception $e) {
+
+    // Entity not found.
     drupal_not_found();
     exit();
   }
-  return $entity;
 }
 
 /**
@@ -41,7 +62,13 @@ function visualization_entity_menu() {
   );
 }
 
+/**
+ * Implements hook_menu_alter().
+ */
 function visualization_entity_menu_alter(&$items){
+
+  // Override routing to use our custom loader instead of
+  // eckentity loader.
   foreach ($items as $key => $value) {
     if(strpos($key, '%eckentity') !== FALSE && strpos($key, 'visualization') !== FALSE) {
       $new_key = str_replace('%eckentity', '%visualization_entity', $key);
@@ -96,6 +123,7 @@ function visualization_entity_attach_embed_widget($markup, $element) {
   }
   return $markup;
 }
+
 /**
  * Renders iframe view for visualization.
  *
@@ -116,10 +144,12 @@ function visualization_entity_iframe($entity) {
   }
 }
 
+/**
+ * Implements hook_entity_info_alter().
+ */
 function visualization_entity_entity_info_alter(&$entity_info) {
-  if(uuid_is_valid(arg(2))) {
-    $entity_info['visualization']['uri callback'] = 'visualization_entity_uri';
-  }
+  // Override the default eck__entity__uri to allow uuids in the url.
+  $entity_info['visualization']['uri callback'] = 'visualization_entity_uri';
 }
 
 /**
@@ -129,15 +159,17 @@ function visualization_entity_entity_info_alter(&$entity_info) {
  *   an object as returned by entity_load().
  */
 function visualization_entity_uri($entity) {
-
+  module_load_include('inc', 'eck', 'eck.entity');
+  $crud_info = get_bundle_crud_info($entity->entityType(), $entity->bundle());
+  $view_path = '';
   // Override visualization uri by uuid.
-  if(property_exists($entity, 'uuid')) {
-    module_load_include('inc', 'eck', 'eck.entity');
-    $crud_info = get_bundle_crud_info($entity->entityType(), $entity->bundle());
+  if(property_exists($entity, 'uuid') && uuid_is_valid(arg(2))) {
     $view_path = str_replace('%eckentity', $entity->uuid, $crud_info['view']['path']);
-    return array('path' => $view_path);
+  } else {
+    $ids = entity_extract_ids($entity->entityType(), $entity);
+    $view_path = str_replace('%eckentity', $ids[0], $crud_info['view']['path']);
   }
-  return array('path' => '');
+  return array('path' => $view_path);
 }
 
 /**

--- a/visualization_entity.module
+++ b/visualization_entity.module
@@ -7,18 +7,48 @@
 include_once 'visualization_entity.features.inc';
 include_once drupal_get_path('module', 'visualization_entity') . '/includes/utils.inc';
 
+
+/**
+ * Load callback for %visualization_entity.
+ */
+function visualization_entity_load($entity_id) {
+  if(is_numeric($entity_id)) {
+    $entity = entity_load_single(
+      'visualization',
+      $entity_id
+    );
+  } else if (function_exists('entity_uuid_load') && uuid_is_valid($entity_id)) {
+    $entity = entity_uuid_load('visualization', array($entity_id));
+    $entity =  ($entity) ? reset($entity) : FALSE;
+  } else {
+    drupal_not_found();
+    exit();
+  }
+  return $entity;
+}
+
 /**
  * Implements hook_menu().
  */
 function visualization_entity_menu() {
   return array(
-    'visualization/%/%/iframe' => array(
+    'visualization/%/%visualization_entity/iframe' => array(
       'title' => 'Visualization',
       'page callback' => 'visualization_entity_iframe',
       'page arguments' => array(2),
       'access arguments' => array('access content'),
     ),
   );
+}
+
+function visualization_entity_menu_alter(&$items){
+  foreach ($items as $key => $value) {
+    if(strpos($key, '%eckentity') !== FALSE && strpos($key, 'visualization') !== FALSE) {
+      $new_key = str_replace('%eckentity', '%visualization_entity', $key);
+      $items[$new_key] = $items[$key];
+      unset($items[$key]);
+    }
+  }
 }
 
 /**
@@ -75,12 +105,7 @@ function visualization_entity_attach_embed_widget($markup, $element) {
  * @return string
  *   A rendered entity or MENU_NOT_FOUND constant
  */
-function visualization_entity_iframe($entity_id) {
-  $entity = entity_load_single(
-    'visualization',
-    $entity_id
-  );
-
+function visualization_entity_iframe($entity) {
   if (!empty($entity)) {
     $entity_view = entity_view('visualization', array($entity), 'full');
     $visualization = drupal_render($entity_view);
@@ -89,6 +114,30 @@ function visualization_entity_iframe($entity_id) {
   else {
     return MENU_NOT_FOUND;
   }
+}
+
+function visualization_entity_entity_info_alter(&$entity_info) {
+  if(uuid_is_valid(arg(2))) {
+    $entity_info['visualization']['uri callback'] = 'visualization_entity_uri';
+  }
+}
+
+/**
+ * Entity URI callback.
+ *
+ * @param object $entity
+ *   an object as returned by entity_load().
+ */
+function visualization_entity_uri($entity) {
+
+  // Override visualization uri by uuid.
+  if(property_exists($entity, 'uuid')) {
+    module_load_include('inc', 'eck', 'eck.entity');
+    $crud_info = get_bundle_crud_info($entity->entityType(), $entity->bundle());
+    $view_path = str_replace('%eckentity', $entity->uuid, $crud_info['view']['path']);
+    return array('path' => $view_path);
+  }
+  return array('path' => '');
 }
 
 /**

--- a/visualization_entity.module
+++ b/visualization_entity.module
@@ -112,10 +112,11 @@ function visualization_entity_entity_view_alter(&$build, $type) {
  * Markup for embed widget.
  */
 function visualization_entity_attach_embed_widget($markup, $element) {
+  $id = ($element['#entity']->uuid) ? $element['#entity']->uuid : $element['#entity']->id;
   $module_path = drupal_get_path('module', 'visualization_entity');
   $embed_url = current_path();
   if (!is_numeric(strpos($embed_url, '/iframe'))) {
-    $embed_url = $embed_url . '/iframe';
+    $embed_url = '/' . $element['#entity_type'] . '/' . $element['#bundle'] . '/' . $id . '/iframe';
     $embed_url = url($embed_url, array('absolute' => TRUE));
     $embed_button = theme('visualization-embed-button', array('embed_url' => $embed_url));
     $markup .= $embed_button;


### PR DESCRIPTION
### Description

In order to export visualizations, url should be unique. The only way we can achieve that is by using uuids intead of regular nids. Even though eck entity is  prepared to use uuids, it's not prepared to use uuids in the urls. This means you can't view a visualization using a uuid.

To solve this issue we override the eckentity loader (hook_load) with our custom loader visualization_entity (hook_load) but since original urls are used by eck internally we had to override the uri callback for visualization entities.
### Aceptance criteria
- [x] go to admin/structure/entity-type/visualization/properties
- [x] uuid property should be checked
- [x] create a chart /admin/structure/entity-type/visualization/ve_chart/add
- [x] grab the uuid from the database
- [x] access to the chart view by uuid and nid
- [x] chart should be displayed in the same way for both
- [x] access to the chart edition by uuid and nid
- [x] edition should work in the same way for both
- [x] delete the chart edition by uuid and nid
- [x] deletion should work in the same way for both
