### PR TITLE
Fix Undefined index error on panelizer page 

### DIFF
--- a/modules/visualization_entity_embed/visualization_entity_embed.module
+++ b/modules/visualization_entity_embed/visualization_entity_embed.module
@@ -34,9 +34,11 @@ function visualization_entity_embed_admin_info($subtype, $conf, $contexts) {
   if (!empty($conf)) {
     $block = new stdClass();
     $block->title = $conf['override_title'] ? $conf['override_title_text'] : '';
-    $block->content = t('Source: @source', array(
-      '@source' => $conf['source'],
-    ));
+    if(isset($conf['source'])) {
+      $block->content = t('Source: @source', array(
+        '@source' => $conf['source'],
+      ));
+    }
 
     return $block;
   }


### PR DESCRIPTION
## Issue
#civic-2787

## Description

When using the 'external' source field on the visualization embed feature in panels, user will see this error when editing the panels: 
```
Notice: Undefined index: source in visualization_entity_embed_admin_info() (line 38 of /var/www/dkan_default_content/dkan/modules/contrib/visualization_entity/modules/visualization_entity_embed/visualization_entity_embed.module).
```

## Acceptance Criteria

1. Create a dashboard node
2. Add a visualization using the external source option
3. Save node
4. Click the panelizer tab, then 'Content'
5. You should not see an undefined index warning

## QA site
https://github.com/NuCivic/dkan/pull/1191