### PR TITLE
Add core = 7.x to vis_entity_embed info file

### DIFF
--- a/modules/visualization_entity_embed/visualization_entity_embed.info
+++ b/modules/visualization_entity_embed/visualization_entity_embed.info
@@ -1,6 +1,7 @@
 name = Visualization Entity Embed
 description = Create visualization panes for panels
 package = Data Visualization
+core = 7.x
 version = 7.x-1.x-dev
 
 dependencies[] = visualization_entity


### PR DESCRIPTION
without `core=7.x` in the info file the module is disabled on install