### PR TITLE
Fixed 'edit/delete' paths on visualization tables

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,3 @@
+7.x-1.x
+-------
+- Fixed 'edit/delete' paths used on 'edit/delete' links on visualization tables.

--- a/visualization_entity.module
+++ b/visualization_entity.module
@@ -151,6 +151,10 @@ function visualization_entity_iframe($entity) {
 function visualization_entity_entity_info_alter(&$entity_info) {
   // Override the default eck__entity__uri to allow uuids in the url.
   $entity_info['visualization']['uri callback'] = 'visualization_entity_uri';
+  // Override edit/delete paths.
+  $crud_info = $entity_info['visualization']['bundles']['ve_chart']['crud'];
+  $crud_info['edit']['path'] = "visualization/ve_chart/%eckentity/edit";
+  $crud_info['delete']['path'] = "visualization/ve_chart/%eckentity/delete";
 }
 
 /**

--- a/visualization_entity.module
+++ b/visualization_entity.module
@@ -152,8 +152,10 @@ function visualization_entity_entity_info_alter(&$entity_info) {
   // Override the default eck__entity__uri to allow uuids in the url.
   $entity_info['visualization']['uri callback'] = 'visualization_entity_uri';
 
-  // Override edit/delete paths for visualization bundles. This paths are the
-  // ones used on the 'edit/delete' links displayed on the visualization tables.
+  // Override default edit/delete paths used on visualization tables 
+  // on admin pages. Change default paths with the form 
+  // 'admin/structure/entity-type/visualization/ve_chart/NODE_ID/edit' 
+  // to '/visualization/ve_chart/NODE_ID/edit'.
   $bundles = $entity_info['visualization']['bundles'];
   foreach ($bundles as $bundle_name => $bundle_data) {
     // Override 'Edit' path.

--- a/visualization_entity.module
+++ b/visualization_entity.module
@@ -151,10 +151,18 @@ function visualization_entity_iframe($entity) {
 function visualization_entity_entity_info_alter(&$entity_info) {
   // Override the default eck__entity__uri to allow uuids in the url.
   $entity_info['visualization']['uri callback'] = 'visualization_entity_uri';
-  // Override edit/delete paths.
-  $crud_info = $entity_info['visualization']['bundles']['ve_chart']['crud'];
-  $crud_info['edit']['path'] = "visualization/ve_chart/%eckentity/edit";
-  $crud_info['delete']['path'] = "visualization/ve_chart/%eckentity/delete";
+
+  // Override edit/delete paths for visualization bundles. This paths are the
+  // ones used on the 'edit/delete' links displayed on the visualization tables.
+  $bundles = $entity_info['visualization']['bundles'];
+  foreach ($bundles as $bundle_name => $bundle_data) {
+    // Override 'Edit' path.
+    $entity_info['visualization']['bundles'][$bundle_name]['crud']['edit']['path'] =
+        'visualization/' . $bundle_name . '/%eckentity/edit';
+    // Override 'Delete' path.
+    $entity_info['visualization']['bundles'][$bundle_name]['crud']['delete']['path'] =
+        'visualization/' . $bundle_name . '/%eckentity/delete';
+  }
 }
 
 /**


### PR DESCRIPTION
Issue: https://jira.govdelivery.com/browse/CIVIC-3834

## Description

Clicking on the 'edit/delete' links displayed on the visualization tables was producing an 'Access denied' error.

## QA steps

- [x] Log in with any user
- [x] Create a chart.
- [x] Go to the view page of the chart.
- [x] Confirm that you can access the 'edit' page from the view page.
- [x] Confirm that you can delete the chart from the view page.
- [x] Go to the list of charts (admin/structure/entity-type/visualization/ve_chart)
- [x] Click on 'edit' and confirm that you can edit the chart.
- [x] Click on 'delete' and confirm that you can delete the chart.

## QA Site

https://github.com/NuCivic/dkan/pull/1518

## Merging process

- [ ] Merge this PR
- [ ] Close the PR created on DKAN for QA