### PR TITLE
CIVIC-4875: Next and prev buttons fails accesibility standards during chart creation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
 7.x-1.x
 -------
 - Fixed 'edit/delete' paths used on 'edit/delete' links on visualization tables.
+- Fixed the Chart form to comply with Section 508 requirements for keyboard access.

--- a/modules/visualization_entity_charts/css/ve_chart.css
+++ b/modules/visualization_entity_charts/css/ve_chart.css
@@ -45,7 +45,7 @@ svg {
   overflow: auto;
   padding: 0px;
 }
-#chart-selector li{
+#chart-selector button{
   height: 180px;
   width: 260px;
   background-size: 260px 180px;
@@ -125,12 +125,12 @@ svg {
 /**
  * Charts thumbnails
  */
-#chart-selector li:hover {
+#chart-selector button:hover {
   border-color: #0088cc;
   cursor: pointer;
 }
 
-#chart-selector li.selected {
+#chart-selector button.selected {
   border-color: #0088cc;
 }
 

--- a/modules/visualization_entity_charts/js/visualization_entity_charts_steps.js
+++ b/modules/visualization_entity_charts/js/visualization_entity_charts_steps.js
@@ -185,9 +185,9 @@ this.recline.View.nvd3 = this.recline.View.nvd3 || {};
                   '<label>Series fields</label>' +
                   '<div>{{seriesFields}}</div>'+
                 '</div>' +
-                '<ul id="chart-selector">' +
+                '<div id="chart-selector">' +
                   '{{#graphTypes}}' +
-                    '<li class="{{value}} {{#selected}}selected{{/selected}}" data-selected="{{value}}"></li>' +
+                    '<button type="button" class="{{value}} {{#selected}}selected{{/selected}}" data-selected="{{value}}"></button>' +
                   '{{/graphTypes}}' +
                 '</ul>' +
               '</div>' +
@@ -205,26 +205,27 @@ this.recline.View.nvd3 = this.recline.View.nvd3 || {};
       };
     },
     events: {
-      'click #chart-selector li': 'selectChart'
+      'click #chart-selector button': 'selectChart'
     },
     selectChart: function(e){
       var self = this;
-      self.$('li').removeClass('selected');
+      self.$('button').removeClass('selected');
       self.$(e.target).addClass('selected');
     },
     getSelected: function(){
       var self = this;
-      return self.$('li.selected').data('selected');
+      return self.$('button.selected').data('selected');
     },
     render: function(){
       var self = this;
-      var graphTypes = ['discreteBarChart', 'multiBarChart', 'multiBarHorizontalChart', 'stackedAreaChart', 'pieChart',
-        'lineChart', 'lineWithFocusChart', 'scatterChart', 'linePlusBarChart'
+      var graphTypes = [
+        'discreteBarChart', 'multiBarChart', 'multiBarHorizontalChart', 'stackedAreaChart',
+        'pieChart', 'lineChart', 'lineWithFocusChart', 'scatterChart', 'linePlusBarChart'
       ];
-
-      self.state.set('graphTypes', _.applyOption(
-        _.arrayToOptions(graphTypes), [self.state.get('graphType') || 'discreteBarChart']
-      ));
+      self.state.set('graphTypes', graphTypes.map(function(type, index){
+        var selected = type === (self.state.get('graphType') || 'discreteBarChart' );
+        return {value: type, selected: selected};
+      }));
       self.$el.html(Mustache.render(self.template, self.state.toJSON()));
       self.$('.chosen-select').chosen({width: '95%'});
     },

--- a/modules/visualization_entity_charts/js/visualization_entity_charts_steps.js
+++ b/modules/visualization_entity_charts/js/visualization_entity_charts_steps.js
@@ -60,7 +60,7 @@ this.recline.View.nvd3 = this.recline.View.nvd3 || {};
                 '</div>' +
               '</div>' +
               '<div class="col-md-12" id="controls">' +
-                '<div id="prev" class="btn btn-default pull-left">Back</div>' +
+                '<button type="button" id="prev" class="btn btn-default pull-left">Back</button>' +
                 '<button type="submit" class="form-submit btn btn-success pull-right">Finish</button>' +
               '</div>',
     events: {
@@ -192,8 +192,8 @@ this.recline.View.nvd3 = this.recline.View.nvd3 || {};
                 '</ul>' +
               '</div>' +
               '<div id="controls">' +
-                '<div id="prev" class="btn btn-default pull-left">Back</div>' +
-                '<div id="next" class="btn btn-primary pull-right">Next</div>' +
+                '<button type="button" id="prev" class="btn btn-default pull-left">Back</button>' +
+                '<button type="button" id="next" class="btn btn-primary pull-right">Next</button>' +
               '</div>',
     initialize: function(options){
       var self = this;
@@ -268,8 +268,8 @@ this.recline.View.nvd3 = this.recline.View.nvd3 || {};
                   '{{/xDataTypes}}' +
                 '</div>' +
                 '<div id="controls">' +
-                  '<div id="prev" class="btn btn-default pull-left">Back</div>' +
-                  '<div id="next" class="btn btn-primary pull-right">Next</div>' +
+                  '<button type="button" id="prev" class="btn btn-default pull-left">Back</button>' +
+                  '<button type="button" id="next" class="btn btn-primary pull-right">Next</button>' +
                 '</div>' +
               '</div>',
     initialize: function(options){
@@ -323,7 +323,7 @@ this.recline.View.nvd3 = this.recline.View.nvd3 || {};
                 '</select>' +
               '</div>' +
               '<div id="controls">' +
-                '<div id="next" class="btn btn-primary pull-right">Next</div>' +
+                '<button type="button" id="next" class="btn btn-primary pull-right">Next</button>' +
               '</div>',
     initialize: function(options){
       var self = this;


### PR DESCRIPTION
Issue: CIVIC-4875

The Add Chart form fails as the user can not tab to the 'Next' button.

## QA Steps
- [x] Go to admin/structure/entity-type/visualization/ve_chart/add
- [x] Focus at any form element
- [x] Try to reach the next button using tab
- [x] Repeat in all the steps

## Acceptance criteria
- [x] You can focus in Back and Next / Finish buttons using tab.