### PR TITLE
fix undefined error on install CIVIC-5050

### DIFF
--- a/visualization_entity.module
+++ b/visualization_entity.module
@@ -156,14 +156,16 @@ function visualization_entity_entity_info_alter(&$entity_info) {
   // on admin pages. Change default paths with the form 
   // 'admin/structure/entity-type/visualization/ve_chart/NODE_ID/edit' 
   // to '/visualization/ve_chart/NODE_ID/edit'.
-  $bundles = $entity_info['visualization']['bundles'];
-  foreach ($bundles as $bundle_name => $bundle_data) {
-    // Override 'Edit' path.
-    $entity_info['visualization']['bundles'][$bundle_name]['crud']['edit']['path'] =
-        'visualization/' . $bundle_name . '/%eckentity/edit';
-    // Override 'Delete' path.
-    $entity_info['visualization']['bundles'][$bundle_name]['crud']['delete']['path'] =
-        'visualization/' . $bundle_name . '/%eckentity/delete';
+  $bundles = isset($entity_info['visualization']['bundles']) ? $entity_info['visualization']['bundles'] : '';
+  if ($bundles) {
+    foreach ($bundles as $bundle_name => $bundle_data) {
+      // Override 'Edit' path.
+      $entity_info['visualization']['bundles'][$bundle_name]['crud']['edit']['path'] =
+          'visualization/' . $bundle_name . '/%eckentity/edit';
+      // Override 'Delete' path.
+      $entity_info['visualization']['bundles'][$bundle_name]['crud']['delete']['path'] =
+          'visualization/' . $bundle_name . '/%eckentity/delete';
+    }
   }
 }
 


### PR DESCRIPTION
## Description
When running `ahoy dkan reinstall` 
```
Undefined index: bundles in visualization_entity_entity_info_alter() (line 159 of
/var/www/dkan/modules/contrib/visualization_entity/visualization_entity.module).

Invalid argument supplied for foreach() in visualization_entity_entity_info_alter() (line 160 of
/var/www/dkan/modules/contrib/visualization_entity/visualization_entity.module).
```
## Acceptance Steps
No errors on visualization_entity when running the dkan install command