### PR TITLE
Fix chosen accesibility for visualization entity

### DIFF
--- a/modules/visualization_entity_charts/js/visualization_entity_charts_steps.js
+++ b/modules/visualization_entity_charts/js/visualization_entity_charts_steps.js
@@ -430,6 +430,7 @@ this.recline.View.nvd3 = this.recline.View.nvd3 || {};
         self.state = state;
         self.gotoStep(n);
         self.trigger('multistep:change', {step:n});
+        self.$('.chosen-choices .search-field input, .chosen-search input').attr('aria-label', 'Choose some options');
       };
     },
     gotoStep: function(n){


### PR DESCRIPTION
Description
-----------
Chosen fields in visualization entity charts don't use the chosen drupal module.
Because this patch proposed by @jacinto only fix normal drupal fields using the
drupal chosen module.

Solution
--------
This PR fixes chosen fields each time user change the step in the chart creation.

QA Steps
--------
- [x] Navigate to `/admin/structure/entity-type/visualization/ve_chart/add`
- [x] Use the gold prices resource
- [x] Press next
- [x] Run wave accesibility tool
- [x] No red flags should be displayed

Acceptance criteria
-------------------
- Chosen fields (select and lookup views) should not display red flags when wave tool it's ran.