### PR TITLE
Remove dataproxy option from the charts source type field CIVIC-5964

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 7.x-1.x
 -------
+- Removed dataproxy as an option from the Select backend source type field on charts.
 - Fixed 'edit/delete' paths used on 'edit/delete' links on visualization tables.
 - Fixed the Chart form to comply with Section 508 requirements for keyboard access.

--- a/modules/visualization_entity_charts/js/visualization_entity_charts_steps.js
+++ b/modules/visualization_entity_charts/js/visualization_entity_charts_steps.js
@@ -320,7 +320,6 @@ this.recline.View.nvd3 = this.recline.View.nvd3 || {};
                 '<select title="Select backend source type" id="control-chart-backend" class="form-control">' +
                   '<option value="csv">CSV</option>' +
                   '<option value="gdocs">Google Spreadsheet</option>' +
-                  '<option value="dataproxy">DataProxy</option>' +
                 '</select>' +
               '</div>' +
               '<div id="controls">' +


### PR DESCRIPTION
Issue: CIVIC-5964
## Description
The dataproxy option on the chart form does not function and is not needed. Remove it.

## QA steps
1. Create a chart
2. Under Load Data, the source type field should only display CSV and Google Spreadsheet as options. 

![add_chart___dkan](https://cloud.githubusercontent.com/assets/314172/23805039/f087a45a-0581-11e7-86ac-f09bc3335cfb.png)
