### PR TITLE
Allow embed visualizations from external sites #CIVIC-5658

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.x
 -------
+- Fixed x-frame-options error on embeded chart visualizations.
 - Add help text to configuration fields in the chart entity form.
 - Added 'Data type' settings also for series values ('y' values).
 - Fixed parsing of 'Numeral' values on series.

--- a/visualization_entity.module
+++ b/visualization_entity.module
@@ -136,13 +136,22 @@ function visualization_entity_attach_embed_widget($markup, $element) {
  */
 function visualization_entity_iframe($entity) {
   if (!empty($entity)) {
-    header_remove('X-Frame-Options');
     $entity_view = entity_view('visualization', array($entity), 'full');
     $visualization = drupal_render($entity_view);
     return $visualization;
   }
   else {
     return MENU_NOT_FOUND;
+  }
+}
+
+/**
+ * Implements hook_page_alter().
+ */
+function visualization_entity_page_alter(&$page) {
+  $menu = menu_get_item();
+  if(!empty($menu) && isset($menu['path']) && $menu['path'] == 'visualization/%/%/iframe') {
+    header_remove('X-Frame-Options');
   }
 }
 

--- a/visualization_entity.module
+++ b/visualization_entity.module
@@ -136,6 +136,7 @@ function visualization_entity_attach_embed_widget($markup, $element) {
  */
 function visualization_entity_iframe($entity) {
   if (!empty($entity)) {
+    header_remove('X-Frame-Options');
     $entity_view = entity_view('visualization', array($entity), 'full');
     $visualization = drupal_render($entity_view);
     return $visualization;
@@ -152,9 +153,9 @@ function visualization_entity_entity_info_alter(&$entity_info) {
   // Override the default eck__entity__uri to allow uuids in the url.
   $entity_info['visualization']['uri callback'] = 'visualization_entity_uri';
 
-  // Override default edit/delete paths used on visualization tables 
-  // on admin pages. Change default paths with the form 
-  // 'admin/structure/entity-type/visualization/ve_chart/NODE_ID/edit' 
+  // Override default edit/delete paths used on visualization tables
+  // on admin pages. Change default paths with the form
+  // 'admin/structure/entity-type/visualization/ve_chart/NODE_ID/edit'
   // to '/visualization/ve_chart/NODE_ID/edit'.
   $bundles = isset($entity_info['visualization']['bundles']) ? $entity_info['visualization']['bundles'] : '';
   if ($bundles) {


### PR DESCRIPTION
Issue: CIVIC-5658

Removes the x-frame-options header from visualization embeds.

## QA Steps
- [x] Go to any visualization entity charts
- [x] Copy the embed iframe
- [x] Try to embed that in another site
- [x] Embed should work