### PR TITLE
Use local path for uploaded files CIVIC-6140

### DIFF
--- a/modules/visualization_entity_charts/js/visualization_entity_charts.js
+++ b/modules/visualization_entity_charts/js/visualization_entity_charts.js
@@ -97,6 +97,7 @@
         $(document).ajaxComplete(function(e, xhr, settings) {
           if(settings.url && settings.url.search('/file/ajax/field_file') !== -1){
             var url = $('.file-widget a').prop('href');
+            var url = url.replace(/.*\/\/[^\/]*/, '');
             var source = {backend:'csv', url: url};
             sharedObject.state.set('source', source);
             msv.gotoStep(0);


### PR DESCRIPTION
Issue: CIVIC-6140

## Description
When charts are created on production environments using the upload file option, the url saved in the configuration is the production url, when the chart is viewed from the staging environment you will get an error: `Failed to fetch the resource`

This change will strip out the domain and save the url as a local url.

## Steps to reproduce

* Visit a visualization on a test website
* If that visualization's "Source" field does not already point to the full URL of the resource on the production site, edit it so it does point to Upon saving and trying to view the visualization, you will see a popup message that says, "Failed to fetch the resource."
* Now edit the visualization again and change the "Source" field to a local path
* Upon saving, you will be able to view the visualization as intended.

## QA Steps

* Simply create a chart from an uploaded file, embed on a page and inspect the embed to make sure the resource is using a local path