### PR TITLE
Remove version numbers on info files

### DIFF
--- a/modules/visualization_entity_charts/modules/visualization_entity_charts_dkan/visualization_entity_charts_dkan.info
+++ b/modules/visualization_entity_charts/modules/visualization_entity_charts_dkan/visualization_entity_charts_dkan.info
@@ -2,6 +2,7 @@ name = Visualization Entity Charts DKAN
 description = Add charts to dkan
 core = 7.x
 package = Other
+
 dependencies[] = dkan_dataset
 dependencies[] = dkan_datastore
 dependencies[] = features

--- a/modules/visualization_entity_charts/visualization_entity_charts.info
+++ b/modules/visualization_entity_charts/visualization_entity_charts.info
@@ -2,7 +2,6 @@ name = Visualization Entity Charts
 description = Create charts using nvd3
 core = 7.x
 package = Data Visualization
-version = 7.x-1.x-dev
 
 dependencies[] = chosen
 dependencies[] = ctools

--- a/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.info
+++ b/modules/visualization_entity_choropleth_bundle/visualization_entity_choropleth_bundle.info
@@ -2,7 +2,6 @@ name = Visualization Entity Choropleth Bundle
 description = Create choropleth map visualizations using leaflet
 core = 7.x
 package = Data Visualization
-version = 7.x-1.x-dev
 
 dependencies[] = list
 dependencies[] = text

--- a/modules/visualization_entity_embed/visualization_entity_embed.info
+++ b/modules/visualization_entity_embed/visualization_entity_embed.info
@@ -2,6 +2,5 @@ name = Visualization Entity Embed
 description = Create visualization panes for panels
 package = Data Visualization
 core = 7.x
-version = 7.x-1.x-dev
 
 dependencies[] = visualization_entity

--- a/modules/visualization_entity_geojson_bundle/visualization_entity_geojson_bundle.info
+++ b/modules/visualization_entity_geojson_bundle/visualization_entity_geojson_bundle.info
@@ -2,7 +2,6 @@ name = Visualization Entity Geojson Bundle
 description = Plot simple geojson data on a map. Expiremental.
 core = 7.x
 package = Data Visualization
-version = 7.x-1.x-dev
 
 dependencies[] = libraries
 dependencies[] = geo_file_entity

--- a/modules/visualization_entity_geojson_bundle/visualization_entity_geojson_bundle.info
+++ b/modules/visualization_entity_geojson_bundle/visualization_entity_geojson_bundle.info
@@ -10,5 +10,4 @@ dependencies[] = visualization_entity
 features[eck_bundle][] = visualization_geojson_visualization
 features[features_api][] = api:2
 features[field_instance][] = visualization-geojson_visualization-field_uuid_resource
-mtime = 1421033934
 project path = sites/all/modules/nucivic/visualization_entity/modules

--- a/modules/visualization_entity_recline_field_reference/visualization_entity_recline_field_reference.info
+++ b/modules/visualization_entity_recline_field_reference/visualization_entity_recline_field_reference.info
@@ -2,7 +2,6 @@ name = Visualization Entity Recline Field Reference
 description = DKAN Integration module. Provides a field to visualization entity to link DKAN resources. See http://github.com/NuCivic/dkan for more information.
 core = 7.x
 package = Data Visualization
-version = 7.x-1.x-dev
 
 dependencies[] = entityreference
 dependencies[] = dkan_dataset_content_types
@@ -11,5 +10,4 @@ dependencies[] = uuidreference
 dependencies[] = uuidreference_select
 features[features_api][] = api:2
 features[field_base][] = field_uuid_resource
-mtime = 1426610294
 project path = profiles/dkan/modules/contrib

--- a/modules/visualization_entity_visualization_contributor_role/visualization_entity_visualization_contributor_role.info
+++ b/modules/visualization_entity_visualization_contributor_role/visualization_entity_visualization_contributor_role.info
@@ -1,7 +1,6 @@
 name = Visualization Entity Visualization Contributor Role
 core = 7.x
 package = Data Visualization
-version = 7.x-1.x-dev
 
 dependencies[] = entity
 dependencies[] = features

--- a/visualization_entity.info
+++ b/visualization_entity.info
@@ -2,7 +2,7 @@ name = Visualization Entity
 description = Base module to create visualizations
 core = 7.x
 package = Data Visualization
-version = 7.x-1.x-dev
+
 dependencies[] = eck
 dependencies[] = features
 features[eck_entity_type][] = visualization


### PR DESCRIPTION
The visualization entity module will be getting automatic releases synced to DKAN now. Remove existing (and out-of-date) version lines in info files to allow DKAN release script to fill in information.